### PR TITLE
HDFS-17105. mistakenly purge editLogs even after it is empty in NNStorageRetentionManager

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorageRetentionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorageRetentionManager.java
@@ -80,6 +80,9 @@ public class NNStorageRetentionManager {
     Preconditions.checkArgument(numExtraEditsToRetain >= 0,
         DFSConfigKeys.DFS_NAMENODE_NUM_EXTRA_EDITS_RETAINED_KEY +
         " must not be negative");
+    Preconditions.checkArgument(maxExtraEditsSegmentsToRetain >= 0,
+        DFSConfigKeys.DFS_NAMENODE_MAX_EXTRA_EDITS_SEGMENTS_RETAINED_KEY +
+        " must not be negative");
     
     this.storage = storage;
     this.purgeableLogs = purgeableLogs;


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17105

This PR adds a non-negative check for the parameter `dfs.namenode.num.extra.edits.retained`.

### How was this patch tested

(1) Set `dfs.namenode.max.extra.edits.segments.retained` to `-1`
(2) Run test: `org.apache.hadoop.hdfs.server.namenode.TestNNStorageRetentionManager#testNoLogs`
An `IllegalArgumentException` is thrown rather than the `IndexOutOfBoundsException`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?