### PR TITLE
YARN-11530. Server$Listener stating too many open files when setting ipc.server.read.threadpool.size big enough

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -1426,10 +1426,20 @@ public abstract class Server {
       selector= Selector.open();
       readers = new Reader[readThreads];
       for (int i = 0; i < readThreads; i++) {
-        Reader reader = new Reader(
-            "Socket Reader #" + (i + 1) + " for port " + port);
-        readers[i] = reader;
-        reader.start();
+        try {
+            Reader reader = new Reader(
+                "Socket Reader #" + (i + 1) + " for port " + port);
+            readers[i] = reader;
+            reader.start();
+        } catch (IOException e) {
+            if (e.getMessage().equals("Too many open files")) {
+                throw new IOException("The number of readers for the server is set larger than the system limit. " +
+                        "Consider lowering " + CommonConfigurationKeys.IPC_SERVER_RPC_READ_THREADS_KEY + 
+                        " or the number of readers configured for the server.", e);
+            } else {
+                throw e;
+            }
+        }
       }
 
       // Register accepts on the server socket with the selector.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -1433,6 +1433,11 @@ public abstract class Server {
             reader.start();
         } catch (IOException e) {
             if (e.getMessage().equals("Too many open files")) {
+                // close the opened readers
+                running = false;
+                for (int j = 0; j < i; j++) {
+                    readers[j].shutdown();
+                }
                 throw new IOException("The number of readers for the server is set larger than the system limit. " +
                         "Consider lowering " + CommonConfigurationKeys.IPC_SERVER_RPC_READ_THREADS_KEY + 
                         " or the number of readers configured for the server.", e);


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/YARN-11530

This PR adds a catch for the too many open files to avoid crashing the system and also shuts down the readers already opened to allow for customized failovers and later actions.

### How was this patch tested?
(1) set ipc.server.read.threadpool.size to 50000
(2) run org.apache.hadoop.yarn.TestRPCFactories#test
An extra IOException hinting where the problem is can be observed in the output of the test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

