### PR TITLE
HADOOP-18802. Collision of config key name fs.viewfs.mounttable.default.name.key to other keys that specify the entry point to mount tables

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -46,7 +46,7 @@ public interface Constants {
    * Config key to specify the name of the default mount table.
    */
   String CONFIG_VIEWFS_DEFAULT_MOUNT_TABLE_NAME_KEY =
-      "fs.viewfs.mounttable.default.name.key";
+      "fs.viewfs.mounttable.default-name-key";
 
   /**
    * Config variable name for the default mount table.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ViewFsOverloadScheme.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ViewFsOverloadScheme.md
@@ -179,10 +179,10 @@ For example, when the following configuration is used but a path like `viewfs:/f
 ```
 
 ### Solution
-To avoid the above problem, the configuration `fs.viewfs.mounttable.default.name.key` has to be set to the name of the cluster, i.e, the following should be added to `core-site.xml`
+To avoid the above problem, the configuration `fs.viewfs.mounttable.default-name-key` has to be set to the name of the cluster, i.e, the following should be added to `core-site.xml`
 ```xml
 <property>
-  <name>fs.viewfs.mounttable.default.name.key</name>
+  <name>fs.viewfs.mounttable.default-name-key</name>
   <value>cluster</value>
 </property>
 ```


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18802

This PR changes the name of the previous `fs.viewfs.mounttable.default.name.key` to `fs.viewfs.mounttable.default-name-key` to avoid collision.
I grepped for the parameter name and changed/corrected it in all places.

### How was this patch tested?
(1) set `fs.viewfs.mounttable.default-name-key` to `default`
(2) run `org.apache.hadoop.fs.viewfs.TestFcMainOperationsLocalFs#testGlobStatusWithMultipleWildCardMatches`
the test passes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

