### PR TITLE
HADOOP-18800. Bad ipc.client.connection.idle-scan-interval.ms cause resource leaks

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.util.ExitUtil;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.ProtoUtil;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
@@ -3996,6 +3997,8 @@ public abstract class Server {
           new ConcurrentHashMap<Connection,Boolean>(
               maxQueueSize, 0.75f, readThreads+2));
       this.userToConnectionsMap = new ConcurrentHashMap<>();
+      Preconditions.checkArgument(idleScanInterval >= 0, "%s should be non-negative", 
+          CommonConfigurationKeys.IPC_CLIENT_CONNECTION_IDLESCANINTERVAL_KEY);
     }
 
     private boolean add(Connection connection) {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18800
This PR adds a non-negative check for the idle scan duration.

### How was this patch tested?
(1) Set `ipc.client.connection.idle-scan-interval.ms` to `-1`
(2) Run test `org.apache.hadoop.ipc.TestIPC#testSocketLeak`
The test fails with an illegal argument exception rather than the assertion error mentioned in the issue.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

