### PR TITLE
HDFS-17098. DatanodeManager does not handle null storage type properly

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -666,7 +666,15 @@ public class DatanodeManager {
     Consumer<List<DatanodeInfoWithStorage>> secondarySort = null;
     if (readConsiderStorageType) {
       Comparator<DatanodeInfoWithStorage> comp =
-          Comparator.comparing(DatanodeInfoWithStorage::getStorageType);
+          Comparator.comparing(DatanodeInfoWithStorage::getStorageType, (s1, s2) -> {
+               if (s1 == null) {
+                    return (s2 == null) ? 0 : -1;
+                } else if (s2 == null) {
+                    return 1;
+                } else {
+                    return s2.compareTo(s1);
+                }
+          });
       secondarySort = list -> Collections.sort(list, comp);
     }
     if (readConsiderLoad) {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17098

This PR changes the comparator for the secondary sort using storage type to one that puts null first.

### How was this patch tested?
(1) Set dfs.heartbeat.interval to 1753310367, and dfs.namenode.read.considerStorageType to true
(2) Run test: org.apache.hadoop.hdfs.server.blockmanagement.TestSortLocatedBlock#testAviodStaleAndSlowDatanodes
Observe that `NullPointerException` is no longer thrown.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

