### PR TITLE
HADOOP-18831. Missing null check when running doRun method

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
@@ -257,11 +257,15 @@ public abstract class ZKFailoverController {
       LOG.error("The failover controller encounters runtime error: ", e);
       throw e;
     } finally {
-      rpcServer.stopAndJoin();
+      if (rpcServer != null) {
+        rpcServer.stopAndJoin();
+      }
       
       elector.quitElection(true);
-      healthMonitor.shutdown();
-      healthMonitor.join();
+      if (healthMonitor != null) {
+          healthMonitor.shutdown();
+          healthMonitor.join();
+      }
     }
     return 0;
   }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18831
This PR adds a null check for `rpcServer` and `healthMonitor` in `ZKFailoverController.java`.

### How was this patch tested?
(1) set `ipc.server.handler.queue.size` to `0`
(2) run `org.apache.hadoop.ha.TestZKFailoverController#testAutoFailoverOnLostZKSession
The test throws an `IllegalArgumentException`, which it should, instead of a `NullPointerException`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

