### PR TITLE
MAPREDUCE-7454. missing checking for null when acquiring appId for a null jobId

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobResourceUploader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobResourceUploader.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RpcNoSuchMethodException;
 import org.apache.hadoop.mapreduce.filecache.ClientDistributedCacheManager;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.client.api.SharedCacheClient;
@@ -75,6 +76,7 @@ class JobResourceUploader {
   private void initSharedCache(JobID jobid, Configuration conf) {
     this.scConfig.init(conf);
     if (this.scConfig.isSharedCacheEnabled()) {
+      Preconditions.checkArgument(jobid != null, "JobId cannot be null if shared cache is enabled");
       this.scClient = createSharedCacheClient(conf);
       appId = jobIDToAppId(jobid);
     }
@@ -88,6 +90,7 @@ class JobResourceUploader {
    * mapreduce-client-common.
    */
   private ApplicationId jobIDToAppId(JobID jobId) {
+    Preconditions.checkArgument(jobId != null, "Cannot acquire the ApplicationId for a null JobId");
     return ApplicationId.newInstance(Long.parseLong(jobId.getJtIdentifier()),
         jobId.getId());
   }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/MAPREDUCE-7454
This PR adds a nullity check for the jobId when trying to acquire the appId, and also when trying to initialize the shared cache.

### How was this patch tested?
1. set `mapreduce.job.sharedcache.mode=archives, mapreduce.framework.name=yarn, yarn.sharedcache.enabled=true`
2. run `org.apache.hadoop.mapreduce.TestJobResourceUploader#testErasureCodingDisabled`
The test does not throw `NullPointerException` any more, and gives more information about what is the problem.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

